### PR TITLE
Bumping up to ADAL v1.1.16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.3.0'
 
     // Azure Active Directory Library
-    compile 'com.microsoft.aad:adal:1.1.13'
+    compile 'com.microsoft.aad:adal:1.1.16'
 
     // Retrofit + custom HTTP
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.0.0'

--- a/app/src/main/java/com/microsoft/office365/connectmicrosoftgraph/AuthenticationManager.java
+++ b/app/src/main/java/com/microsoft/office365/connectmicrosoftgraph/AuthenticationManager.java
@@ -122,9 +122,6 @@ public class AuthenticationManager {
         } else {
             Log.e(TAG,
                     "connect - Auth context verification failed. Did you set a context activity?");
-            throw new AuthenticationException(
-                    ADALError.ACTIVITY_REQUEST_INTENT_DATA_IS_NULL,
-                    "Auth context verification failed. Did you set a context activity?");
         }
     }
 
@@ -149,7 +146,6 @@ public class AuthenticationManager {
                             } else {
                                 authenticationCallback.onError(
                                         new Exception(authenticationResult.getErrorDescription()));
-
                             }
                         } else {
                             // I could not authenticate the user silently,


### PR DESCRIPTION
We no longer need to throw **AuthenticationException** since the error
is handled in the **onError** method of the callback.